### PR TITLE
docs: add investigations as the output of a technical spike

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,33 @@ together today — one topic-named file per concept
 [`0000-template.md`](docs/concepts/0000-template.md). Keep them current:
 if a change makes one inaccurate, update it in the same PR.
 
+## Investigations
+
+An investigation ([`docs/investigations/`](docs/investigations/)) is what
+a technical spike produces — what was found, and what to do about it.
+Number sequentially (`000x-question.md`) from
+[`0000-template.md`](docs/investigations/0000-template.md).
+
+Working alone and intermittently, there's no second person carrying the
+context between sessions. That's the whole reason these are written down
+rather than held in someone's head, and it's the bar for whether one is
+worth writing: **would a reader six months from now otherwise re-derive
+this from scratch?** If not, skip it and put the finding straight into
+whichever doc permanently owns it.
+
+**An investigation is not an ADR.** It records what was found; an ADR
+records what was decided. An investigation that leads to a decision
+justifies an ADR rather than replacing it — write both and link them.
+
+Lead with the verdict, not the evidence. A spike resolves to **new
+complexity** or **no new complexity**; the latter closes the spike and
+opens a fresh ticket for the work itself.
+
+Investigations ship through a PR and carry a Status like any other work.
+Durable facts about a dependency belong in that dependency's own
+reference docs too — record them in both places rather than letting this
+folder become the only copy.
+
 ## Issues
 
 Labels: `User Value` (direct value to the CLI's user) · `Developer

--- a/docs/investigations/0000-template.md
+++ b/docs/investigations/0000-template.md
@@ -1,0 +1,64 @@
+<!--
+An investigation is what a technical spike produces. It records what was
+found, so the finding survives the gap between work sessions.
+
+Lead with the verdict. A spike's deliverable is a decision, not a
+report — if a reader has to reach the evidence before they know what to
+do, the order is wrong. Evidence goes underneath, for the reader who
+wants to check the reasoning or reuse a fact two years later.
+
+Use the right doc type:
+- Investigation — "what did we find out, and what should we do?"
+- ADR           — "what did we decide, and why did the alternatives lose?"
+- Concept       — "how does this work today?"
+
+An investigation that leads to a decision doesn't become an ADR — it
+justifies one. Write both and link them.
+
+Durable facts about a dependency belong in that dependency's own
+reference docs as well, not only here. Record them in both places and
+say where the permanent home is.
+-->
+
+# NNNN. The question being answered
+
+- **Status:** In Development | In Review | Complete
+- **Spike:** #NN
+- **Time-box:** the box agreed when the spike was estimated
+- **Date:** YYYY-MM-DD
+
+## Verdict
+
+New complexity, or no new complexity. One paragraph, no hedging.
+
+If no new complexity: say so plainly. The spike closes and a fresh
+ticket carries the work.
+
+If new complexity: say what it is, in the terms a breakdown needs.
+
+## Recommendation
+
+What should happen next, concretely enough to slice into a parent ticket
+and estimable sub-tickets.
+
+## What was established
+
+The durable facts — the ones that stay true regardless of what gets
+decided. Note where each one's permanent home is if it belongs somewhere
+other than this file.
+
+## Evidence
+
+How each fact above was established. Real commands, real files, real
+versions. Enough that a reader can re-run it rather than trust it.
+
+## Open questions
+
+What remains unanswered, phrased as questions. Include anything the
+time-box cut short — a spike that stops at the box with questions open
+is working correctly, not failing.
+
+## Out of scope
+
+What this deliberately didn't examine, so the next reader doesn't assume
+it was checked.


### PR DESCRIPTION
Addresses #196. Stacked on #198, which is stacked on #197 — **merge both first.**

`docs/adr/` records what was decided and `docs/concepts/` records how something works today. Neither records what was *found out*. This adds `docs/investigations/` as the output of a technical spike.

## What's here

`docs/investigations/0000-template.md` — verdict-first, with Status / Spike / Time-box / Date, then Verdict, Recommendation, What was established, Evidence, Open questions, Out of scope. A comment header explains when to reach for an investigation over an ADR or a concept.

A new Investigations section in `CONTRIBUTING.md`, sitting alongside the existing ADR and Concepts sections.

## The reasoning

**Verdict first.** A spike's deliverable is a decision, not a report. If a reader has to reach the evidence before they know what to do, the order is wrong. Evidence goes underneath, for whoever wants to check the reasoning later.

**An investigation is not an ADR.** It records what was found; an ADR records what was decided. One that leads to a decision justifies an ADR rather than replacing it — write both and link them.

**Two outcomes.** A spike resolves to new complexity or no new complexity. The latter closes the spike and opens a fresh, cleanly-titled delivery ticket rather than retitling the spike in place.

**The bar for writing one** is stated as the solo-work rationale, not as a rule for its own sake: *would a reader six months from now otherwise re-derive this from scratch?* If not, skip it and put the finding straight into whichever doc permanently owns it. There's no second person carrying context between sessions here, and that's the whole reason these get written down.

**Durable facts about a dependency belong in that dependency's own reference docs too**, so this folder doesn't become the only copy of something YnabSharp should be recording itself.

Convention only — no investigation is written here. `0001` follows once there's a spike to attach it to.
