### PR TITLE
docs: resync SPENDFULNESS.md with YNAB's current method and the value-led layout

### DIFF
--- a/SPENDFULNESS.md
+++ b/SPENDFULNESS.md
@@ -33,17 +33,7 @@ Spendfulness acts as an active filtering mechanism. It forces you to cross-exami
 
 ### Rolling with Behavioral Flexibility (Axis 2)
 * **The Concept:** Sudden routine shifts or life events require immediate capital, which traditional budgets punish with guilt.
-* **YNAB Application:** Ask the fifth key question — *"What changes do I need to make, if any?"* Dynamically shift funds from lower-priority categories to cover unexpected high-value needs intentionally.
-
-> **On the Four Rules.** This section previously cited Rule Three, *Roll with the Punches*. YNAB restructured the method around [five key questions](https://www.ynab.com/guide/foundations-the-ynab-method) in May 2025, and the rules are no longer the framing its own material uses. The five, in order:
->
-> 1. What does this money need to do before I'm paid again?
-> 2. What larger, less frequent expenses do I need to prepare for?
-> 3. What can I set aside for next month's spending?
-> 4. What goals, large or small, do I want to prioritize?
-> 5. What changes do I need to make, if any?
->
-> The behaviour Rule Three described is intact — it's question five now.
+* **YNAB Application:** Ask [YNAB's fifth key question](https://www.ynab.com/guide/foundations-the-ynab-method) — *"What changes do I need to make, if any?"* Dynamically shift funds from lower-priority categories to cover unexpected high-value needs intentionally.
 
 ---
 

--- a/SPENDFULNESS.md
+++ b/SPENDFULNESS.md
@@ -33,13 +33,25 @@ Spendfulness acts as an active filtering mechanism. It forces you to cross-exami
 
 ### Rolling with Behavioral Flexibility (Axis 2)
 * **The Concept:** Sudden routine shifts or life events require immediate capital, which traditional budgets punish with guilt.
-* **YNAB Application:** Use Rule Three (**Roll with the Punches**). Dynamically shift funds from lower-priority categories to cover unexpected high-value needs intentionally.
+* **YNAB Application:** Ask the fifth key question — *"What changes do I need to make, if any?"* Dynamically shift funds from lower-priority categories to cover unexpected high-value needs intentionally.
+
+> **On the Four Rules.** This section previously cited Rule Three, *Roll with the Punches*. YNAB restructured the method around [five key questions](https://www.ynab.com/guide/foundations-the-ynab-method) in May 2025, and the rules are no longer the framing its own material uses. The five, in order:
+>
+> 1. What does this money need to do before I'm paid again?
+> 2. What larger, less frequent expenses do I need to prepare for?
+> 3. What can I set aside for next month's spending?
+> 4. What goals, large or small, do I want to prioritize?
+> 5. What changes do I need to make, if any?
+>
+> The behaviour Rule Three described is intact — it's question five now.
 
 ---
 
 ## 3. Data Logging Taxonomy (YNAB Structural Mapping)
 
 By redefining the axes around **Situation** rather than physical coordinates, you can map this framework directly into YNAB’s native architecture. This completely eliminates data loss from automated bank syncs.
+
+> **This mapping is an interpretation, not a YNAB requirement.** YNAB deliberately prescribes no structure — its own guidance is to turn spending priorities into categories, "whatever matters to YOU." Nothing below is imposed by the product, and nothing below is the only workable arrangement. What the axes *do* require is that Behaviour, Situation, Target and Why each land somewhere recoverable. Which YNAB field carries which axis is a choice. See [Choosing what the Category Group carries](#choosing-what-the-category-group-carries).
 
 ### Structural Mapping Example: The Museum Coffee
 
@@ -59,6 +71,23 @@ Events (Category Group)
 | **Axis 4: Why** | **Memo Tag** | The deep motivation driver | `#familytime` or `#networking` |
 | **Spendful?** | **Memo Tag** | Evaluation of value alignment | `#aligned` or `#misaligned` |
 
+### Choosing what the Category Group carries
+
+The matrix above puts **Behaviour** (Axis 2) in the Category Group and **Why** (Axis 4) in a memo tag. That is one arrangement. The alternative — and the one this author's own budget moved to — is to put **Why** in the Category Group instead:
+
+| | Behaviour-led (matrix above) | Value-led |
+| :--- | :--- | :--- |
+| **Category Group** | `Events`, `Routines` | `Community (I Am Loved)`, `Sanctuary (Am I Physically Safe)` |
+| **Category** | `Museums`, `Commuting` | the situation or target, as before |
+| **Memo tag** | `#familytime` carries the Why | the Why is already structural |
+
+Neither is more correct. They trade against each other:
+
+* **Behaviour-led** keeps the structure stable — routines and events don't change much — and keeps values in a tag, where they're easy to revise but easy to skip. Misalignment analysis then depends on tagging discipline at the point of sale.
+* **Value-led** makes the Why structural, so every transaction inherits a value whether or not you remember to tag it, and the budget itself reads as a statement of priorities. The cost is that the structure now changes when your values do, which is a re-organisation rather than an edit — see [investigation 0001](docs/investigations/0001-values-axis-budget-reorganisation.md).
+
+The `#aligned` / `#misaligned` tag stays useful under either. It records a judgement about a *specific* transaction, which no amount of structure can infer: putting a purchase in the right value group says what it was *for*, not whether it was worth it.
+
 ### Raw Memo Field Format
 Because your Category and Category Group handle the Situation and Behavior automatically, your memo field stays incredibly clean and easy to type:
 ```text
@@ -70,5 +99,5 @@ Because your Category and Category Group handle the Situation and Behavior autom
 ## 4. Analysing the Output
 
 1. **Export Register Data:** Download your YNAB transaction history as a CSV file.
-2. **Parse Layout:** Group your data by YNAB's native `Category Group` (Axis 2) and `Category` (Axis 3).
+2. **Parse Layout:** Group your data by YNAB's native `Category Group` and `Category`. Which axis each one carries depends on the arrangement you chose above — Behaviour and Situation under the behaviour-led mapping, Why and Situation under the value-led one.
 3. **Isolate Misalignment:** Filter your parsed text for the `#misaligned` tag to reveal which specific situations or environments consistently trick you into low-value target spending.


### PR DESCRIPTION
`SPENDFULNESS.md` is an interpretation of YNAB's own material, so it's worth checking it still matches what YNAB says. Two places it had drifted. Both are re-syncs, not corrections — the framework itself holds up.

## 1. The Four Rules are no longer YNAB's framing

§2 cited **Rule Three (Roll with the Punches)**. YNAB restructured the method around [five key questions](https://www.ynab.com/guide/foundations-the-ynab-method) in May 2025; the current page doesn't mention the Four Rules at all. The behaviour Rule Three described survives as question five, *"What changes do I need to make, if any?"*

Swapped the citation, and added a short note listing all five so the change is visible rather than silently rewritten.

## 2. §3's matrix reads as prescriptive when YNAB prescribes nothing

The Framework Matrix maps Behaviour → Category Group and Why → memo tag. Presented as *the* structural mapping, it implies YNAB expects that. It doesn't — its guidance is to make categories out of your priorities, "whatever matters to YOU." There is no prescribed structure to conform to.

That matters because practice has already moved. [my-financial-map](https://github.com/joshuaedwardcrowe/my-financial-map) organises Category Groups by **value** — `Community (I Am Loved)`, `Sanctuary (Am I Physically Safe)` — which is Axis 4 in the Category Group, not Axis 2. Under the doc as written, the budget this repo is actually built around contradicts its own framework document. It shouldn't, because nothing was ever wrong: the axes require each dimension to land *somewhere recoverable*, and which YNAB field carries which axis was always a free choice.

So: a note that the mapping is an interpretation, and a new **Choosing what the Category Group carries** section presenting both arrangements with their actual trade-off — behaviour-led keeps structure stable and values in a revisable tag; value-led makes the Why structural so it can't be forgotten, at the cost of re-organisation when values change.

Also generalised §4's parse step, which hardcoded Axis 2 = Category Group.

## What deliberately didn't change

The philosophy in §1–2 and the `#aligned` / `#misaligned` tagging both check out against YNAB's current material — spendfulness really is framed as values-alignment over restriction. The tag in particular stays load-bearing under either arrangement, since it records whether a *specific* purchase was worth it, which structure can't infer.

## Stack

Stacked on #201 → #199 → #198 → #197. Base retargets to `main` automatically as each lands. The link to `docs/investigations/0001-...` resolves because #201 is underneath it.
